### PR TITLE
User administration patch

### DIFF
--- a/RTBot.py
+++ b/RTBot.py
@@ -215,8 +215,10 @@ class RTBot(MUCJabberBot):
             t = ( args.jid, )
             c.execute('INSERT INTO ops VALUES (?)', t)
             c.commit()
-
             dbconn.close()
+
+            logging.info('%s made %s an op.' % (chatter, args.jid))
+
             return 'OK, made %s an op.' % args.jid
 
         if args.level == 'user':
@@ -227,6 +229,8 @@ class RTBot(MUCJabberBot):
             t = ( args.jid, )
             c.execute('INSERT INTO users VALUES (?)', t)
             c.commit()
+
+            logging.info('%s made %s a user.' % (chatter, args.jid))
 
             dbconn.close()
             return 'OK, made %s a user.' % args.jid

--- a/RTBot.py
+++ b/RTBot.py
@@ -193,8 +193,8 @@ class RTBot(MUCJabberBot):
             return 'You are not an op nor an admin.'
 
         parser = argparse.ArgumentParser(description='useradd command parser')
-        parser.add_argument('type', choices=['op', 'user'],
-                help='What kind of permission to give.')
+        parser.add_argument('level', choices=['op', 'user'],
+                help='What kind of permission level to give.')
         parser.add_argument('jid', help='Username of person to add.')
 
         try:
@@ -207,24 +207,24 @@ class RTBot(MUCJabberBot):
         c.execute('SELECT * FROM users')
         users = c.fetchall()
 
-        if args.type == op:
+        if args.level == 'op':
             if args.jid in ops:
                 dbconn.close()
                 return '%s is already an op.' % args.jid
 
-            t = ( args.jid )
+            t = ( args.jid, )
             c.execute('INSERT INTO ops VALUES (?)', t)
             c.commit()
 
             dbconn.close()
             return 'OK, made %s an op.' % args.jid
 
-        if args.type == user:
+        if args.level == 'user':
             if args.jid in users:
                 dbconn.close()
                 return '%s is already a user.' % args.jid
 
-            t = ( args.jid )
+            t = ( args.jid, )
             c.execute('INSERT INTO users VALUES (?)', t)
             c.commit()
 

--- a/RTBot.py
+++ b/RTBot.py
@@ -341,6 +341,7 @@ class RTBot(MUCJabberBot):
             logging.info('Edit kohbesok request from %s' % mess.getFrom())
 
             if not chatter in ops:
+                dbconn.close()
                 logging.info('%s (not op) tried to edit koh post.' % chatter)
                 return "You are not an op and cannot edit."
 
@@ -349,6 +350,7 @@ class RTBot(MUCJabberBot):
             rs = c.fetchone()
             if not rs:
                 dbconn.close()
+                logging.info('%s tried to edit non-existing data' % chatter)
                 return "There is no data on this date yet."
 
             old_value = rs[1]

--- a/RTBot.py
+++ b/RTBot.py
@@ -244,6 +244,16 @@ class RTBot(MUCJabberBot):
         dbconn = sqlite3.connect(self.db)
         c = dbconn.cursor()
 
+        c.execute('SELECT * FROM ops')
+        ops = c.fetchall()
+        c.execute('SELECT * FROM users')
+        users = c.fetchall()
+
+        if not chatter in users and not chatter in ops:
+            dbconn.close()
+            logging.info('%s, not op nor user tried to run kohbesok.' % chatter)
+            return 'You are neither a registered user or op, go away!'
+
         output = ""
         counter = 0
         for row in c.execute('SELECT * FROM kohbesok ORDER BY date DESC'):

--- a/RTBot.py
+++ b/RTBot.py
@@ -182,7 +182,7 @@ class RTBot(MUCJabberBot):
 
         dbconn = sqlite3.connect(self.db)
         c = dbconn.cursor()
-        chatter, resource = mess.getFrom().split('/')
+        chatter, resource = str(mess.getFrom()).split('/')
 
         c.execute('SELECT * FROM ops')
         ops = c.fetchall()

--- a/RTBot.py
+++ b/RTBot.py
@@ -314,6 +314,7 @@ class RTBot(MUCJabberBot):
         users = c.fetchall()
 
         if not chatter in users and not chatter in ops:
+            dbconn.close()
             logging.info('%s, not op nor user tried to run kohbesok.' % chatter)
             return 'You are neither a registered user or op, go away!'
 

--- a/RTBot.py
+++ b/RTBot.py
@@ -201,6 +201,7 @@ class RTBot(MUCJabberBot):
             args = parser.parse_args(words[1:])
         except:
             dbconn.close()
+            logging.info('%s used bad syntax for useradmin.' % chatter)
             return 'Usage: useradd op/user username@domain'
 
         c.execute('SELECT * FROM users')

--- a/RTBot.py
+++ b/RTBot.py
@@ -278,6 +278,7 @@ class RTBot(MUCJabberBot):
         Here the date will also be assumed to be today if you don't specify it.
         """
         words = mess.getBody().strip().split()
+        chatter,resource = str(mess.getFrom()).split('/')
         now = datetime.datetime.now()
         d = datetime.datetime.strftime(now, '%Y-%m-%d')
 
@@ -296,6 +297,15 @@ class RTBot(MUCJabberBot):
 
         dbconn = sqlite3.connect(self.db)
         c = dbconn.cursor()
+
+        c.execute('SELECT * FROM ops')
+        ops = c.fetchall()
+        c.execute('SELECT * FROM users')
+        users = c.fetchall()
+
+        if not chatter in users and not chatter in ops:
+            logging.info('%s, not op nor user tried to run kohbesok.' % chatter)
+            return 'You are neither a registered user or op, go away!'
 
         if args.command == 'register':
             # Check if already registered this date
@@ -319,10 +329,9 @@ class RTBot(MUCJabberBot):
         elif args.command == 'edit':
             logging.info('Edit kohbesok request from %s' % mess.getFrom())
 
-            chatter,resource = str(mess.getFrom()).split('/')
-            if chatter not in ['benedebr@chat.uio.no',
-                    'rersdal@chat.uio.no', 'olsen@chat.uio.no']:
-                return "You are not an op."
+            if not chatter in ops:
+                logging.info('%s (not op) tried to edit koh post.' % chatter)
+                return "You are not an op and cannot edit."
 
             # Update an existing row
             c.execute('SELECT * FROM kohbesok WHERE date=?', (args.date, ))

--- a/RTBot.py
+++ b/RTBot.py
@@ -189,6 +189,7 @@ class RTBot(MUCJabberBot):
 
         if chatter not in ops or chatter != self.admin:
             dbconn.close()
+            logging.info('%s tried to call useradmin.' % chatter)
             return 'You are not an op nor an admin.'
 
         parser = argparse.ArgumentParser(description='useradd command parser')


### PR DESCRIPTION
Adds functionality for adding ops and users. Then easy to fetch all users / ops from db and see who can do stuff. Also, when initializing the bot, take a chat-username that is the admin. This person can add users / ops without being user / op self.
