### PR TITLE
Fix notaddtofuture

### DIFF
--- a/RTBot.py
+++ b/RTBot.py
@@ -565,6 +565,11 @@ class RTBot(MUCJabberBot):
             logging.info('%s, not op nor user tried to run kohbesok.' % chatter)
             return 'You are neither a registered user or op, go away!'
 
+        if datetime.datetime.strptime(args.date, '%Y-%m-%d') > now:
+            dbconn.close()
+            logging.info('%s tried to register %d for %s ignored since in future.' % (chatter, args.visitors, args.date))
+            return 'You cannot register for dates in the future.'
+
         if args.command == 'register':
             # Check if already registered this date
             t = ( args.date, )

--- a/RTBot.py
+++ b/RTBot.py
@@ -565,12 +565,13 @@ class RTBot(MUCJabberBot):
             logging.info('%s, not op nor user tried to run kohbesok.' % chatter)
             return 'You are neither a registered user or op, go away!'
 
-        if datetime.datetime.strptime(args.date, '%Y-%m-%d') > now:
-            dbconn.close()
-            logging.info('%s tried to register %d for %s ignored since in future.' % (chatter, args.visitors, args.date))
-            return 'You cannot register for dates in the future.'
-
         if args.command == 'register':
+            # Check if in future
+            if datetime.datetime.strptime(args.date, '%Y-%m-%d') > now:
+                dbconn.close()
+                logging.info('%s tried to register %d for %s ignored since in future.' % (chatter, args.visitors, args.date))
+                return 'You cannot register for dates in the future.'
+
             # Check if already registered this date
             t = ( args.date, )
             c.execute('SELECT * FROM kohbesok WHERE date=?', t)


### PR DESCRIPTION
Bot should not let you register visitors for dates in the future.

Awaiting todays registration before merge to be sure no mess-up for todays date. If-check should not be activate if the two dates are the same date.
